### PR TITLE
INTR-94: add overview.md and bump version

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -1,0 +1,3 @@
+# HiddenLayer Model Scanner Azure DevOps Task
+
+Integrate model scanning into your continuous integration (CI) process with HiddenLayer's Azure DevOps task.

--- a/task/package.json
+++ b/task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Model Scanner",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "index.js",
   "scripts": {
     "build": "tsc",

--- a/task/task.json
+++ b/task/task.json
@@ -10,7 +10,7 @@
   "version": {
       "Major": 0,
       "Minor": 4,
-      "Patch": 0
+      "Patch": 1
   },
   "instanceNameFormat": "HiddenLayer Model Scan for $(modelPath)",
   "inputs": [

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -3,7 +3,7 @@
   "public": true,
   "id": "model-scanner-task",
   "name": "HiddenLayer Model Scanner",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "hiddenlayer",
   "targets": [
       {
@@ -14,6 +14,11 @@
   "categories": [
       "Azure Pipelines"
   ],
+  "content": {
+      "details": {
+          "path": "overview.md"
+      }
+  },
   "icons": {
       "default": "images/extension-icon.png"        
   },


### PR DESCRIPTION
When attempting to publish the Azure DevOps task, the following error was returned:

```
error: The supplied extension definition isn't valid: 'Uploaded extension package is missing an 'overview.md' file which is a mandatory details asset. Try again after adding the file.'.
```

This PR addresses this error by adding the missing overview.md.