### PR TITLE
fix community scan model location

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To scan a folder, you can add the following yaml to your pipeline:
 - task: ModelScanner@1
   inputs:
     modelName: 'dev-azure-devops-community-scanme'
-    modelPath: 'ScanMe/Models'
+    modelPath: 'ScanMe/test-models'
     apiUrl: 'https://api.us.hiddenlayer.ai'
     failOnDetections: false
     sarifFile: security/output.sarif

--- a/overview.md
+++ b/overview.md
@@ -107,7 +107,7 @@ steps:
 - task: ModelScanner@1
   inputs:
     modelName: 'dev-azure-devops-community-scanme'
-    modelPath: 'ScanMe/Models'
+    modelPath: 'ScanMe/test-models'
     apiUrl: 'https://api.us.hiddenlayer.ai'
     failOnDetections: false
     sarifFile: security/output.sarif

--- a/task/tests/community_scan_success_without_fail_on_detections.ts
+++ b/task/tests/community_scan_success_without_fail_on_detections.ts
@@ -8,7 +8,7 @@ const taskPath = path.join(__dirname, '..', 'index.js');
 const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
 console.log(__dirname);
-tmr.setInput('modelPath', 'ScanMe/Models');
+tmr.setInput('modelPath', 'ScanMe/test-models');
 tmr.setInput('apiUrl', process.env['HL_API_URL'] || 'https://api.us.hiddenlayer.ai');
 tmr.setInput('hlClientID', process.env['HL_CLIENT_ID'] || '');
 tmr.setInput('hlClientSecret', process.env['HL_CLIENT_SECRET'] || '');
@@ -17,4 +17,4 @@ tmr.setInput('sarifFile', __dirname + '/results/results_community_scan_success_w
 tmr.setInput('communityScan', 'HUGGING_FACE');
 tmr.setInput('modelVersion', 'main');
 
-tmr.run(); 
+tmr.run();


### PR DESCRIPTION
## Describe your changes

Based on the recent HuggingFace changes, this PR:
* updates the location of the model for community scan to `ScanMe/test-models`

## Issue ticket number and link
